### PR TITLE
Ensure reharmonization menu resets after analysis change

### DIFF
--- a/script.js
+++ b/script.js
@@ -600,6 +600,7 @@ function initRearmonizador(options = {}) {
                     .map(o => `<option value="${o.chords.join(' ')}" data-name="${o.name}">${o.name}</option>`)
                     .join('');
                 rehSel.innerHTML = `<option value="">Rearmonizar...</option>${newOpts}`;
+                rehSel.selectedIndex = 0;
             });
 
             rehSel.addEventListener('change', ev => {


### PR DESCRIPTION
## Summary
- reset reharmonization dropdown when the analysis selection changes

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_687139734a088333b634cc28815831bc